### PR TITLE
Making redirect URL an .env variable

### DIFF
--- a/src/services/authAPI.js
+++ b/src/services/authAPI.js
@@ -3,7 +3,7 @@ import axios from "axios";
 class authAPI {
 
     static authorizeApp(apiKey) {
-        window.open(`${process.env.REACT_APP_BASE_URL}authorize/?key=${apiKey}&return_url=http://localhost:3000/&callback_method=fragment&scope=read,write&expiration=1hour&name=trelloClientApp&response_type=fragment`, "_self");
+        window.open(`${process.env.REACT_APP_BASE_URL}authorize/?key=${apiKey}&return_url=${process.env.REACT_APP_REDIRECT_URL}&callback_method=fragment&scope=read,write&expiration=1hour&name=trelloClientApp&response_type=fragment`, "_self");
     }
 
     static async getTokenInfo(apiKey, token) {


### PR DESCRIPTION
After this, .env file will require: REACT_APP_REDIRECT_URL="http://localhost:3000/" for token auth to function.